### PR TITLE
nm: log exception before returning None

### DIFF
--- a/comitup/nm.py
+++ b/comitup/nm.py
@@ -57,7 +57,8 @@ def none_on_exception(*exceptions):
             try:
                 return fp(*args, **kwargs)
             except exceptions:
-                log.debug("Got an exception, returning None, %s" % fp.__name__)
+                log.debug("Got an exception, returning None, %s", fp.__name__,
+                          exc_info=True)
                 return None
 
         return wrapper


### PR DESCRIPTION
This helps to identify underlying issues when trying to spawn an accesspoint.