### PR TITLE
conf: explain primary device

### DIFF
--- a/conf/comitup.conf
+++ b/conf/comitup.conf
@@ -57,5 +57,6 @@
 #
 # By default, the first wifi device returned by NetworkManager is used as
 # the primary wifi device. This allows you to override this choice.
+# The primary device is used to spawn the access point.
 #
 # primary_wifi_device: wlan0


### PR DESCRIPTION
The semantic of a primary device is not explained anywhere else.