### PR TITLE
Do not transform SSIDs to uppercase

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -16,7 +16,7 @@
     <div class="uk-width-large uk-padding-small">
         <div class="uk-width-1-1 uk-text-center">
             <span class="" uk-icon="icon: world; ratio: 5"></span>
-            <p class="uk-text-large">Choose Wifi Connection</p>
+            <p class="uk-text-large">Choose WiFi Connection</p>
         </div>
 
         <div class="uk-margin">
@@ -24,11 +24,11 @@
                 {% for point in points %}
                     {% if point.security == 'encrypted' %}
                         <a href="confirm?ssid={{ point.ssid_encoded }}&encrypted={{ point.security }}">
-                            <button class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom"><span uk-icon="icon: lock"></span> {{ point.ssid }}</button>
+                            <button class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom" style="text-transform: none;"><span uk-icon="icon: lock"></span> {{ point.ssid }}</button>
                         </a>
                     {% else %}
                         <a href="confirm?ssid={{ point.ssid_encoded }}&encrypted={{ point.security }}">
-                            <button class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom">{{ point.ssid }}</button>
+                            <button class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom" style="text-transform: none;">{{ point.ssid }}</button>
                         </a>
                     {% endif %}
                 {% endfor %}


### PR DESCRIPTION
The `uk-button` class defines `text-transform: uppercase` as per https://github.com/davesteele/comitup/blob/master/web/templates/css/uikit.css#L1818. It is misleading to see your SSID transformed to uppercase.

There are a number of (CSS-)ways to fix this and I opted for the least invasive. One could of course argue that inline styles are no-go. I can change this if you like.

Side note: the UIkit [first defines `none`](https://github.com/davesteele/comitup/blob/master/web/templates/css/uikit.css#L1831) and then [`uppercase` a few lines below](https://github.com/davesteele/comitup/blob/master/web/templates/css/uikit.css#L1844) in the same class...