### PR TITLE
Add custom Zeroconf service name, load config from /boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 *egg-info
 *swp
 build
+.idea/*
+venv/*

--- a/comitup/comitup.py
+++ b/comitup/comitup.py
@@ -56,6 +56,7 @@ def load_data():
                     'ap_name': 'comitup-<nnn>',
                     'ap_password': '',
                     'web_service': '',
+                    'service_name': 'workstation',
                     'external_callback': '/usr/local/bin/comitup-callback',
                 },
              )

--- a/comitup/comitup.py
+++ b/comitup/comitup.py
@@ -8,6 +8,7 @@
 import argparse
 import logging
 import os
+import shutil
 import random
 import sys
 from logging.handlers import TimedRotatingFileHandler
@@ -27,6 +28,7 @@ from comitup import wificheck    # noqa
 
 PERSIST_PATH = "/var/lib/comitup/comitup.json"
 CONF_PATH = "/etc/comitup.conf"
+BOOT_CONF_PATH = "/boot/comitup.conf"
 LOG_PATH = "/var/log/comitup.log"
 
 
@@ -50,6 +52,14 @@ def deflog():
 
 
 def load_data():
+    if os.path.isfile(BOOT_CONF_PATH):
+        try:
+            dest = shutil.copyfile(BOOT_CONF_PATH, CONF_PATH)
+            print("Boot config file copied:", dest)
+            os.remove(BOOT_CONF_PATH)
+        except: 
+            print("Error occurred while copying file.")
+
     conf = config.Config(
                 CONF_PATH,
                 defaults={

--- a/comitup/comitup.py
+++ b/comitup/comitup.py
@@ -8,12 +8,12 @@
 import argparse
 import logging
 import os
-import shutil
-import random
 import sys
 from logging.handlers import TimedRotatingFileHandler
 
 from dbus.mainloop.glib import DBusGMainLoop
+
+
 DBusGMainLoop(set_as_default=True)
 from gi.repository.GLib import MainLoop  # noqa
 
@@ -26,9 +26,6 @@ from comitup import sysd         # noqa
 from comitup import webmgr       # noqa
 from comitup import wificheck    # noqa
 
-PERSIST_PATH = "/var/lib/comitup/comitup.json"
-CONF_PATH = "/etc/comitup.conf"
-BOOT_CONF_PATH = "/boot/comitup.conf"
 LOG_PATH = "/var/log/comitup.log"
 
 
@@ -49,34 +46,6 @@ def deflog():
     log.addHandler(handler)
 
     return log
-
-
-def load_data():
-    if os.path.isfile(BOOT_CONF_PATH):
-        try:
-            dest = shutil.copyfile(BOOT_CONF_PATH, CONF_PATH)
-            print("Boot config file copied:", dest)
-            os.remove(BOOT_CONF_PATH)
-        except: 
-            print("Error occurred while copying file.")
-
-    conf = config.Config(
-                CONF_PATH,
-                defaults={
-                    'ap_name': 'comitup-<nnn>',
-                    'ap_password': '',
-                    'web_service': '',
-                    'service_name': 'workstation',
-                    'external_callback': '/usr/local/bin/comitup-callback',
-                },
-             )
-
-    data = persist.persist(
-                PERSIST_PATH,
-                {'id': str(random.randrange(1000, 9999))},
-           )
-
-    return (conf, data)
 
 
 def check_environment(log):
@@ -118,7 +87,7 @@ def main():
     log = deflog()
     log.info("Starting comitup")
 
-    (conf, data) = load_data()
+    (conf, data) = config.load_data()
 
     if args.check:
         if wificheck.run_checks():

--- a/comitup/config.py
+++ b/comitup/config.py
@@ -12,6 +12,15 @@
 
 import configparser
 import io
+import os
+import random
+import shutil
+
+from comitup import persist
+
+PERSIST_PATH = "/var/lib/comitup/comitup.json"
+CONF_PATH = "/etc/comitup.conf"
+BOOT_CONF_PATH = "/boot/comitup.conf"
 
 
 class Config(object):
@@ -32,3 +41,31 @@ class Config(object):
             return self._config.get(self._section, tag)
         except configparser.NoOptionError:
             raise AttributeError
+
+
+def load_data():
+    if os.path.isfile(BOOT_CONF_PATH):
+        try:
+            dest = shutil.copyfile(BOOT_CONF_PATH, CONF_PATH)
+            print("Boot config file copied:", dest)
+            os.remove(BOOT_CONF_PATH)
+        except:
+            print("Error occurred while copying file.")
+
+    conf = Config(
+                CONF_PATH,
+                defaults={
+                    'ap_name': 'comitup-<nnn>',
+                    'ap_password': '',
+                    'web_service': '',
+                    'service_name': 'workstation',
+                    'external_callback': '/usr/local/bin/comitup-callback',
+                },
+             )
+
+    data = persist.persist(
+                PERSIST_PATH,
+                {'id': str(random.randrange(1000, 9999))},
+           )
+
+    return (conf, data)

--- a/comitup/mdns.py
+++ b/comitup/mdns.py
@@ -19,7 +19,6 @@ import shutil
 import os
 from comitup import nm
 from comitup import config
-from comitup import persist      # noqa
 import subprocess
 
 log = logging.getLogger('comitup')
@@ -35,10 +34,6 @@ DBUS_PATH_SERVER = '/'
 DBUS_INTERFACE_SERVER = 'org.freedesktop.Avahi.Server'
 DBUS_INTERFACE_ENTRY_GROUP = 'org.freedesktop.Avahi.EntryGroup'
 PROTO_INET = 0
-PERSIST_PATH = "/var/lib/comitup/comitup.json"
-CONF_PATH = "/etc/comitup.conf"
-BOOT_CONF_PATH = "/boot/comitup.conf"
-
 group = None
 
 # functions
@@ -93,7 +88,7 @@ def string_array_to_txt_array(txt_array):
 
 def add_service(host, devindex, addr):
     name = host
-    (conf, data) = load_data()
+    (conf, data) = config.load_data()
     if '.local' in name:
         name = name[:-len('.local')]
 
@@ -139,34 +134,6 @@ def get_interface_mapping():
 
     return mapping
     
-
-def load_data():
-    if os.path.isfile(BOOT_CONF_PATH):
-        try:
-            dest = shutil.copyfile(BOOT_CONF_PATH, CONF_PATH)
-            print("Boot config file copied:", dest)
-            os.remove(BOOT_CONF_PATH)
-        except:
-            print("Error occurred while copying file.")
-
-    conf = config.Config(
-                CONF_PATH,
-                defaults={
-                    'ap_name': 'comitup-<nnn>',
-                    'ap_password': '',
-                    'web_service': '',
-                    'service_name': 'workstation',
-                    'external_callback': '/usr/local/bin/comitup-callback',
-                },
-             )
-
-    data = persist.persist(
-                PERSIST_PATH,
-                {'id': str(random.randrange(1000, 9999))},
-           )
-
-    return (conf, data)
-
 
 def add_hosts(hosts):
     establish_group()

--- a/comitup/mdns.py
+++ b/comitup/mdns.py
@@ -14,7 +14,12 @@
 import dbus
 import socket
 import logging
+import random
+import shutil
+import os
 from comitup import nm
+from comitup import config
+from comitup import persist      # noqa
 import subprocess
 
 log = logging.getLogger('comitup')
@@ -32,6 +37,7 @@ DBUS_INTERFACE_ENTRY_GROUP = 'org.freedesktop.Avahi.EntryGroup'
 PROTO_INET = 0
 PERSIST_PATH = "/var/lib/comitup/comitup.json"
 CONF_PATH = "/etc/comitup.conf"
+BOOT_CONF_PATH = "/boot/comitup.conf"
 
 group = None
 
@@ -135,6 +141,14 @@ def get_interface_mapping():
     
 
 def load_data():
+    if os.path.isfile(BOOT_CONF_PATH):
+        try:
+            dest = shutil.copyfile(BOOT_CONF_PATH, CONF_PATH)
+            print("Boot config file copied:", dest)
+            os.remove(BOOT_CONF_PATH)
+        except:
+            print("Error occurred while copying file.")
+
     conf = config.Config(
                 CONF_PATH,
                 defaults={

--- a/comitup/mdns.py
+++ b/comitup/mdns.py
@@ -30,6 +30,8 @@ DBUS_PATH_SERVER = '/'
 DBUS_INTERFACE_SERVER = 'org.freedesktop.Avahi.Server'
 DBUS_INTERFACE_ENTRY_GROUP = 'org.freedesktop.Avahi.EntryGroup'
 PROTO_INET = 0
+PERSIST_PATH = "/var/lib/comitup/comitup.json"
+CONF_PATH = "/etc/comitup.conf"
 
 group = None
 
@@ -85,6 +87,7 @@ def string_array_to_txt_array(txt_array):
 
 def add_service(host, devindex, addr):
     name = host
+    (conf, data) = load_data()
     if '.local' in name:
         name = name[:-len('.local')]
 
@@ -93,7 +96,7 @@ def add_service(host, devindex, addr):
         PROTO_INET,
         dbus.UInt32(0),
         name,
-        "_workstation._tcp",
+        "_%s._tcp" % conf.service_name,
         "",
         host,
         dbus.UInt16(9),
@@ -129,6 +132,26 @@ def get_interface_mapping():
             pass
 
     return mapping
+    
+
+def load_data():
+    conf = config.Config(
+                CONF_PATH,
+                defaults={
+                    'ap_name': 'comitup-<nnn>',
+                    'ap_password': '',
+                    'web_service': '',
+                    'service_name': 'workstation',
+                    'external_callback': '/usr/local/bin/comitup-callback',
+                },
+             )
+
+    data = persist.persist(
+                PERSIST_PATH,
+                {'id': str(random.randrange(1000, 9999))},
+           )
+
+    return (conf, data)
 
 
 def add_hosts(hosts):

--- a/conf/comitup.conf
+++ b/conf/comitup.conf
@@ -33,6 +33,14 @@
 #
 # web_service: httpd.service
 
+
+# service_name
+#
+# The mdns service name to advertise as. Will be merged with "._tcp" to create the 
+# full string. (e.g. "_workstation._tcp")
+#
+# service_name: workstation
+
 # enable_appliance_mode
 #
 # If enabled (true), and if two wifi adapters are available, comitup will

--- a/doc/comitup-conf.5.md
+++ b/doc/comitup-conf.5.md
@@ -33,6 +33,10 @@ It is located in the _/etc/_ directory.
     such as _apache2.service_ or _nginx.service_. This defaults to a null string,
     meaning no service is controlled.
 
+  * _service_name_:
+    This defines the mdns service name advertised by **comitup**. This defaults to "workstation",
+    and will be advertised as "_workstation._tcp".
+
   * _enable_appliance_mode_:
     By default, comitup will use multiple wifi interfaces, if available, to connect to the
     local hotspot and to the internet simultaneously. Setting this to something other than

--- a/test/test_comitup.py
+++ b/test/test_comitup.py
@@ -9,6 +9,7 @@ from mock import Mock
 import textwrap
 import os
 
+from comitup import config
 from comitup import comitup as ciu
 
 
@@ -62,7 +63,7 @@ def test_ciu_deflog(log_fxt):
 
 
 def test_ciu_loadconf(conf_fxt, persist_fxt):
-    (conf, data) = ciu.load_data()
+    (conf, data) = config.load_data()
     assert conf.ap_name == 'test'
     assert os.path.isfile(persist_fxt)
 


### PR DESCRIPTION
(Re-submitted after rebase/cleanup of original PR)

Pretty straightforward...

Add an option to put "service_name" in comitup.conf, which will then be read and injected into the MDNS service advertiser for zeroconf. Tested and works perfect for my service "_glimmr._tcp". Made sure to keep the default as "workstation" to not break existing instances.

Also, add a check before loading the config that looks for /boot/comitup.conf, and if detected, copies it over the existing config in /etc/comitup.conf and then deletes the config from /boot. This is similar to how Rpi does wifi autoconfig now, and I think would be the perfect finishing touch for the full flashable image. ;)