### PR TITLE
expand ap_name suffix options 

### DIFF
--- a/comitup/config.py
+++ b/comitup/config.py
@@ -33,8 +33,9 @@ REGEX_APNAME_ID = r'<(?<=\<)([n]{1,4}|[M]{1,12}|[s]{1,16})(?=\>)>'
 # matches '<#...>' where # is M... MAC address, 1-12 characters
 #                             s... RPi serial number, 1-16 characters
 #                             n... randomly generated number
-# ID spec may appear anywhere in the apname, with, or without a hyphen separator
-# Valid match examples: <nn>-myname, p1125-<nnn>, <ss>-<hostname>, <hostname>-<MMMM>, first<MMM>second
+# ID spec may appear anywhere in the apname, with/without a '-' separator
+# Valid match examples: <nn>-myname, p1125-<nnn>, <ss>-<hostname>,
+#                       <hostname>-<MMMM>, first<MMM>second
 
 
 class Config(object):

--- a/comitup/config.py
+++ b/comitup/config.py
@@ -15,12 +15,23 @@ import io
 import os
 import random
 import shutil
+import re
+import logging
+import subprocess
 
 from comitup import persist
+
+log = logging.getLogger('comitup')
 
 PERSIST_PATH = "/var/lib/comitup/comitup.json"
 CONF_PATH = "/etc/comitup.conf"
 BOOT_CONF_PATH = "/boot/comitup.conf"
+DEFAULT_AP = "comitup-<nnn>"
+
+# ap_name regex patterns
+REGEX_APNAME_FORMAT = r'[a-zA-Z\<\>](\w*)-\<([nMs]+?)\>'  # validate format name-<###>|<hostname>-<###>
+REGEX_APNAME_SPEC = r'(?<=\-<).+?(?=\>)'   # extract ### from name-<###>, exclude <>
+REGEX_APNAME_SUB = r'<(?<=\-<).+?(?=\>)>'  # sub includes <>, takes second match if <hostname>-<nnn>
 
 
 class Config(object):
@@ -43,19 +54,54 @@ class Config(object):
             raise AttributeError
 
 
+def _getserial():
+    # Extract serial from cpuinfo file
+    cpuserial = "0000000000000000"
+    try:
+        with open('/proc/cpuinfo', 'r') as f:
+            for line in f:
+                if line.startswith('Serial'):  # Serial		: 10000000082acda8
+                    cpuserial = line.split(':')[-1].strip()
+                    break
+
+    except Exception as e:
+        log.error("Failed to parse /proc/cpuinfo for serial number")
+        log.error(e)
+        cpuserial = "ERROR000000000"
+
+    return cpuserial
+
+
+def _get_mac():
+    mac = "000000000000"
+    cmd = "nmcli -f GENERAL.HWADDR device show wlan0".split(' ')
+    try:
+        mac_info = subprocess.check_output(cmd).decode("utf-8")
+        # from: GENERAL.HWADDR:                         DC:A6:32:2B:6D:37
+        # to  : DCA6322B6D37
+        mac = mac_info.replace('GENERAL.HWADDR:', '').replace(':', '').strip()
+
+    except Exception as e:
+        log.error(e)
+
+    return mac
+
+
 def load_data():
     if os.path.isfile(BOOT_CONF_PATH):
         try:
             dest = shutil.copyfile(BOOT_CONF_PATH, CONF_PATH)
             print("Boot config file copied:", dest)
+            log.info("Boot config file copied: {}".format(dest))
             os.remove(BOOT_CONF_PATH)
         except:
             print("Error occurred while copying file.")
+            log.error("Error occurred while copying file.")
 
     conf = Config(
                 CONF_PATH,
                 defaults={
-                    'ap_name': 'comitup-<nnn>',
+                    'ap_name': DEFAULT_AP,
                     'ap_password': '',
                     'web_service': '',
                     'service_name': 'comitup',
@@ -63,9 +109,27 @@ def load_data():
                 },
              )
 
+    # validate that if the ap_name has '<' or '>' and '-', it follows spec
+    if ('<' in conf.ap_name or '>' in conf.ap_name) and \
+            '-' in conf.ap_name and \
+            re.search(REGEX_APNAME_FORMAT, conf.ap_name) is None:
+        log.error("malformed ap name {}, using default {}".format(conf.ap_name, DEFAULT_AP))
+        conf.ap_name = DEFAULT_AP
+
     data = persist.persist(
                 PERSIST_PATH,
                 {'id': str(random.randrange(1000, 9999))},
            )
 
+    spec = re.search(REGEX_APNAME_SPEC, conf.ap_name)
+    if spec is not None:
+        # if spec is 'nnn...' data already includes 'id' random number
+        # get MAC or SerialNumber if required
+        if spec.group().startswith('M'):
+            data['mac'] = _get_mac()
+
+        if spec.group().startswith('s'):
+            data['sn']: _getserial()
+
+    log.debug(data)
     return (conf, data)

--- a/comitup/statemgr.py
+++ b/comitup/statemgr.py
@@ -126,7 +126,7 @@ def expand_ap(ap_name, data):
     if expand_spec_srch is not None:
         # There is a'<###>' section in the ap_name, substitute it
         expand_spec = expand_spec_srch.group()
-        num = len(expand_spec)
+        num = len(expand_spec) - 2 # remove <> contribution
 
         if expand_spec.startswith("<s"):
             id = data.sn[-num:]

--- a/comitup/statemgr.py
+++ b/comitup/statemgr.py
@@ -33,7 +33,7 @@ DBusGMainLoop(set_as_default=True)
 from comitup import states                                 # noqa
 from comitup import nm                                     # noqa
 from comitup import modemgr                                # noqa
-from comitup.config import REGEX_APNAME_SPEC, REGEX_APNAME_SUB
+from comitup.config import REGEX_APNAME_ID
 
 comitup_path = "/com/github/davesteele/comitup"
 
@@ -118,20 +118,21 @@ def get_info(conf, data):
 
 def expand_ap(ap_name, data):
     returnval = ap_name
-    expand_spec_srch = re.search(REGEX_APNAME_SPEC, ap_name)
+
+    expand_spec_srch = re.search(REGEX_APNAME_ID, ap_name)
     if expand_spec_srch is not None:
-        # There is a'-<###>' section of the ap_name, process it
+        # There is a'<###>' section in the ap_name, substitute it
         expand_spec = expand_spec_srch.group()
         num = len(expand_spec)
 
-        if expand_spec.startswith("s"):
+        if expand_spec.startswith("<s"):
             id = data.sn[-num:]
-        elif expand_spec.startswith("M"):
+        elif expand_spec.startswith("<M"):
             id = data.mac[-num:]
-        else:  # default case, we assume <nn...> based on config's validation
+        else:  # default case, we assume <nn...> based on config's REGEX_APNAME_ID validation
             id = data.id[:num]
 
-        returnval = re.sub(REGEX_APNAME_SUB, id, ap_name)
+        returnval = re.sub(REGEX_APNAME_ID, id, ap_name)
 
     returnval = re.sub("<hostname>", socket.gethostname(), returnval)
     log.info("using SSID: {}".format(returnval))

--- a/comitup/statemgr.py
+++ b/comitup/statemgr.py
@@ -36,7 +36,7 @@ DBusGMainLoop(set_as_default=True)
 from comitup import modemgr  # noqa
 from comitup import nm  # noqa
 from comitup import states  # noqa
-from comitup.config import REGEX_APNAME_ID
+from comitup.config import REGEX_APNAME_ID  # noqa
 
 comitup_path = "/com/github/davesteele/comitup"
 
@@ -126,13 +126,13 @@ def expand_ap(ap_name, data):
     if expand_spec_srch is not None:
         # There is a'<###>' section in the ap_name, substitute it
         expand_spec = expand_spec_srch.group()
-        num = len(expand_spec) - 2 # remove <> contribution
+        num = len(expand_spec) - 2  # -2 remove <> contribution
 
         if expand_spec.startswith("<s"):
             id = data.sn[-num:]
         elif expand_spec.startswith("<M"):
             id = data.mac[-num:]
-        else:  # default case, we assume <nn...> based on config's REGEX_APNAME_ID validation
+        else:  # default case <nn...>, based on regex search
             id = data.id[:num]
 
         returnval = re.sub(REGEX_APNAME_ID, id, ap_name)

--- a/comitup/statemgr.py
+++ b/comitup/statemgr.py
@@ -33,9 +33,9 @@ from gi.repository.GLib import MainLoop, timeout_add  # noqa
 
 DBusGMainLoop(set_as_default=True)
 
-from comitup import states                                 # noqa
-from comitup import nm                                     # noqa
-from comitup import modemgr                                # noqa
+from comitup import modemgr  # noqa
+from comitup import nm  # noqa
+from comitup import states  # noqa
 from comitup.config import REGEX_APNAME_ID
 
 comitup_path = "/com/github/davesteele/comitup"

--- a/conf/comitup.conf
+++ b/conf/comitup.conf
@@ -6,10 +6,11 @@
 # ap_name
 #
 # This defines the name used for the AP hotspot, and for the ZeroConf
-# host name. The "<nnn>" string, if present, will be replaced with an
-# instance-unique, persistent number of the same length. There may be
-# up to four "n's" in the string. Similarly, the string "<hostname>"
-# is replaced with the system hostname.
+# host name. The "<nnn>|<MMMM>|<ssss>" string, if present, will be replaced
+# as follows,  <nnn> instance-unique, persistent number of the same length (up to 4)
+#              <MMMM> device WiFi MAC address of the same length (up to 12)
+#              <ssss> device serial number of the same length (up to 16)
+# Similarly, the string "<hostname>" is replaced with the system hostname.
 #
 # ap_name: comitup-<nnn>
 

--- a/doc/comitup-conf.5.md
+++ b/doc/comitup-conf.5.md
@@ -17,10 +17,18 @@ It is located in the _/etc/_ directory.
     By default, comitup will create a hotspot named **comitup-&lt;nnn&gt;**,
     publish an avahi-daemon(8) host entry for **comitup-&lt;nnn&gt;**, and establish
     an mdns identity for **comitup-&lt;nnn&gt;.local**.  Setting this parameter will
-    change the **comitup** string with one of the users choosing. If the
-    configuration variable contains an &lt;nnn&gt; string, with one to 4 "n's", it
-    will be replaced with a persistent, random number. Similarly, the string
-    &lt;hostname&gt; is replaced with the computer's hostname.
+    change the **comitup** string with one of the users choosing. 
+
+    * There are three options for creating a unique identifier, the length of which is
+      determined by the number of letters,
+      * <n...> Random (persisted) number, 1-4 n's
+      * <M...> RPi wlan0 MAC address, 1-12 M's
+      * <s...> RPi Serial Number, 1-16 s's
+      * Note that only one unique identifier is allowed
+
+    * Similarly, the string &lt;hostname&gt; is replaced with the computer's hostname.
+    * The unique identifier may appear anywhere in the name, for example,
+      * rasp-\<nnn\>, \<MMMMMM\>RPi, \<hostname\>-\<ssss\> 
 
   * _ap_password_:
     If this parameter is defined in the configuration file, then the comitup hotspot will

--- a/test/test_statemgr.py
+++ b/test/test_statemgr.py
@@ -83,4 +83,9 @@ Case = namedtuple("ApName", ["input", "out"])
     ]
 )
 def test_expand_ap(ap_name_fxt, case):
-    assert sm.expand_ap(case.input, "1234") == case.out
+    class Object(object):
+        pass
+
+    data=Object()
+    data.id = "1234"
+    assert sm.expand_ap(case.input, data) == case.out

--- a/test/test_statemgr.py
+++ b/test/test_statemgr.py
@@ -80,6 +80,16 @@ Case = namedtuple("ApName", ["input", "out"])
         Case("<hostname>", "host"),
         Case("<hostname>-<n>", "host-1"),
         Case("<bogus>", "<bogus>"),
+        Case("<M>", "1"),
+        Case("<MMMMMM>", "654321"),
+        Case("<hostname>-<MMMMMM>", "host-654321"),
+        Case("<MMMM>-<hostname>", "4321-host"),
+        Case("<MMMM><hostname>", "4321host"),
+        Case("<s>", "1"),
+        Case("<ssssss>", "654321"),
+        Case("<hostname>-<ssssss>", "host-654321"),
+        Case("<ssss>-<hostname>", "4321-host"),
+        Case("<ssss><hostname>", "4321host"),
     ]
 )
 def test_expand_ap(ap_name_fxt, case):
@@ -88,4 +98,6 @@ def test_expand_ap(ap_name_fxt, case):
 
     data=Object()
     data.id = "1234"
+    data.mac = "CBA987654321"
+    data.sn = "1000000087654321"
     assert sm.expand_ap(case.input, data) == case.out


### PR DESCRIPTION
Add this capability,

        # This defines the name used for the AP hotspot, and for the ZeroConf
        # host name. The "<nnn>|<MMMM>|<ssss>" string, if present, will be replaced
        # as follows,  <nnn> instance-unique, persistent number of the same length (up to 4)
        #              <MMMM> device WiFi MAC address of the same length (up to 12)
        #              <ssss> device serial number of the same length (up to 16)
        # Similarly, the string "<hostname>" is replaced with the system hostname.